### PR TITLE
Migrate GH Pages deploy to official action

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -41,7 +41,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.ref == "refs/heads/main" }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
     # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
     concurrency:

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -33,7 +33,7 @@ jobs:
         run: bash ./scripts/render-all.sh
 
       - name: Upload output for deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v2
         with:
           path: out/html
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -41,7 +41,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref === "refs/heads/main"
+    if: ${{ github.ref === "refs/heads/main" }}
     # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
     # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
     concurrency:

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -33,9 +33,8 @@ jobs:
         run: bash ./scripts/render-all.sh
 
       - name: Upload output for deployment
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: newsletters
           path: out/html
 
   deploy:
@@ -61,20 +60,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Grab output from build job
-        uses: actions/download-artifact@v3
-        with:
-          name: newsletters
-          path: out/html
-
       - name: Setup Pages
         uses: actions/configure-pages@v3
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          # Upload entire repository
-          path: out/html
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -41,7 +41,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.ref === "refs/heads/main" }}
+    if: ${{ github.ref == "refs/heads/main" }}
     # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
     # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
     concurrency:

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Generate content
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -36,11 +37,41 @@ jobs:
           name: newsletters
           path: out/html
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref === "refs/heads/main"
+    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: out/html # The folder the action should deploy.
-          CLEAN: true # Automatically remove deleted files from the deploy branch
-        if: ${{ github.ref == 'refs/heads/main' }}
+          name: newsletters
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Build newsletters
         run: bash ./scripts/render-all.sh
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload output for deployment
+        uses: actions/upload-artifact@v3
         with:
           name: newsletters
           path: out/html
@@ -54,12 +55,14 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      # Tell GitHub where we deployed to
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - name: Grab output from build job
+        uses: actions/download-artifact@v3
         with:
           name: newsletters
           path: out/html

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: newsletters
+          path: out/html
 
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -70,7 +71,7 @@ jobs:
         uses: actions/upload-pages-artifact@v2
         with:
           # Upload entire repository
-          path: '.'
+          path: out/html
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Similar to #44 except this uses the official action from GitHub, and uses granular permissions for better security, and explicit concurrency settings (to enable previous deployments still in progress to complete)

Slightly stolen from here: https://github.com/actions/starter-workflows/blob/main/pages/static.yml

**Successful deploy:**

https://dylmye.me/srawn/
https://github.com/dylmye/srawn/actions/runs/5673489288

![image](https://github.com/srobo/srawn/assets/7024578/231c6410-1b20-42c9-91bd-b502d6d7baf5)
