### PR TITLE
Avoid redundant CI work by only building main and pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -3,7 +3,7 @@ name: Render templates
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,7 +3,7 @@ name: Spellcheck
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
There's very little benefit to building every pushed commit and this will mostly duplicate CI runs for open pull requests.