### PR TITLE
GitHub actions updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: '.python-version'
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -33,7 +33,7 @@ jobs:
         run: bash ./scripts/render-all.sh
 
       - name: Upload output for deployment
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: out/html
 
@@ -89,7 +89,7 @@ jobs:
         run: bash ./scripts/render-all.sh
 
       - name: Upload baseline
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           name: build-from-main
           path: out/html
@@ -103,7 +103,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download artifact from this branch's build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github-pages
 
@@ -116,7 +116,7 @@ jobs:
           mv artifact.tar local.tar
 
       - name: Download artifact from main branch build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-from-main
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: '.python-version'
 
@@ -71,7 +71,7 @@ jobs:
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: '.python-version'
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: bash ./scripts/setup.sh
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
 
@@ -78,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: bash ./scripts/setup.sh
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
 


### PR DESCRIPTION
For NodeJS runtime compatibility -- GitHub has deprecated the v16 runtime and now runs everything on v20.

Builds on #78 