### PR TITLE
Fix GitHub Pages build & deploy

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install
         run: yarn install
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
       - name: Build newsletters
         run: bash ./scripts/render-all.sh
 
@@ -195,12 +198,6 @@ jobs:
       # Tell GitHub where we deployed to
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Previously we had `actions/configure-pages` in the wrong CI job, though it's slightly unclear what impact that had. We also were still using an older version of `actions/deploy-pages`, which seems to have been missed in https://github.com/srobo/srawn/pull/80 and which doesn't seem to be compatible with the artifact actions version we're now using.